### PR TITLE
Make web push encryption works with both, chrome and mozilla endpoints

### DIFF
--- a/lib/web_push_encryption.ex
+++ b/lib/web_push_encryption.ex
@@ -4,6 +4,7 @@ defmodule WebPushEncryption do
   """
 
   defdelegate send_web_push(message, subscription, auth_token), to: WebPushEncryption.Push
+  defdelegate send_web_push(message, subscription), to: WebPushEncryption.Push
 
   defdelegate encrypt(message, subscription), to: WebPushEncryption.Encrypt
   defdelegate encrypt(message, subscription, padding_length), to: WebPushEncryption.Encrypt

--- a/lib/web_push_encryption/encrypt.ex
+++ b/lib/web_push_encryption/encrypt.ex
@@ -49,8 +49,8 @@ defmodule WebPushEncryption.Encrypt do
 
     :ok = validate_subscription(subscription)
 
-    client_public_key = Base.url_decode64!(subscription.keys.p256dh)
-    client_auth_token = Base.url_decode64!(subscription.keys.auth)
+    client_public_key = Base.url_decode64!(subscription.keys.p256dh, padding: false)
+    client_auth_token = Base.url_decode64!(subscription.keys.auth, padding: false)
 
     :ok = validate_length(client_auth_token, 16, "Subscription's Auth token is not 16 bytes.")
     :ok = validate_length(client_public_key, 65, "Subscription's client key (p256dh) is invalid.")

--- a/lib/web_push_encryption/push.ex
+++ b/lib/web_push_encryption/push.ex
@@ -23,11 +23,11 @@ defmodule WebPushEncryption.Push do
   """
   @spec send_web_push(message :: binary, subscription :: map, auth_token :: binary) :: {:ok, any} | {:error, atom}
   def send_web_push(message, subscription, auth_token \\ nil)
-  def send_web_push(_message, %{endpoint: @gcm_url <> registrationId} = subscription, nil) do
+  def send_web_push(_message, %{endpoint: @gcm_url <> _registrationId} = _subscription, nil) do
     raise ArgumentError, "send_web_push requires an auth_token for gcm endpoints"
   end
   def send_web_push(message, %{endpoint: endpoint} = subscription, auth_token) do
-    isGcm = String.contains? endpoint,  @gcm_url
+    is_gcm = String.contains? endpoint,  @gcm_url
 
     payload = WebPushEncryption.Encrypt.encrypt(message, subscription)
     headers = [
@@ -37,7 +37,7 @@ defmodule WebPushEncryption.Push do
       {"Crypto-Key", "dh=#{ub64(payload.server_public_key)}"}
     ]
 
-    if isGcm do
+    if is_gcm do
       endpoint = String.replace(endpoint, @gcm_url, @temp_gcm_url)
       headers = headers ++ [{"Authorization", "key=#{auth_token}"}]
     end

--- a/lib/web_push_encryption/push.ex
+++ b/lib/web_push_encryption/push.ex
@@ -21,13 +21,13 @@ defmodule WebPushEncryption.Push do
 
   Returns the result of `HTTPoison.post`
   """
-  @spec send_web_push(message :: binary, subscription :: map, auth_token :: binary) :: {:ok, any} | {:error, atom}
+  @spec send_web_push(message :: binary, subscription :: map, auth_token :: binary | nil) :: {:ok, any} | {:error, atom}
   def send_web_push(message, subscription, auth_token \\ nil)
-  def send_web_push(_message, %{endpoint: @gcm_url <> _registrationId} = _subscription, nil) do
+  def send_web_push(_message, %{endpoint: @gcm_url <> _registration_id}, nil) do
     raise ArgumentError, "send_web_push requires an auth_token for gcm endpoints"
   end
   def send_web_push(message, %{endpoint: endpoint} = subscription, auth_token) do
-    is_gcm = String.contains? endpoint,  @gcm_url
+    is_gcm = String.contains?(endpoint,  @gcm_url)
 
     payload = WebPushEncryption.Encrypt.encrypt(message, subscription)
     headers = [

--- a/lib/web_push_encryption/push.ex
+++ b/lib/web_push_encryption/push.ex
@@ -14,28 +14,34 @@ defmodule WebPushEncryption.Push do
     * `message` is a binary payload. It can be JSON encoded
     * `subscription` is the subscription information received from the client.
        It should have the following form: `%{keys: %{auth: AUTH, p256dh: P256DH}, endpoint: ENDPOIONT}`
-    * `auth_token` is the GCM api key matching the `gcm_sender_id` from the client `manifest.json`
+    * `auth_token` [Optional] is the GCM api key matching the `gcm_sender_id` from the client `manifest.json`.
+       It is not necessary for mozzilla endpoints.
 
   ## Return value
 
   Returns the result of `HTTPoison.post`
   """
   @spec send_web_push(message :: binary, subscription :: map, auth_token :: binary) :: {:ok, any} | {:error, atom}
-  def send_web_push(message, subscription, auth_token)
-  def send_web_push(_message, _subscription, nil) do
-    raise ArgumentError, "send_web_push requires an auth_token"
+  def send_web_push(message, subscription, auth_token \\ nil)
+  def send_web_push(_message, %{endpoint: @gcm_url <> registrationId} = subscription, nil) do
+    raise ArgumentError, "send_web_push requires an auth_token for gcm endpoints"
   end
   def send_web_push(message, %{endpoint: endpoint} = subscription, auth_token) do
-    endpoint = String.replace(endpoint, @gcm_url, @temp_gcm_url)
+    isGcm = String.contains? endpoint,  @gcm_url
 
     payload = WebPushEncryption.Encrypt.encrypt(message, subscription)
     headers = [
       {"TTL", "0"},
       {"Content-Encoding", "aesgcm"},
       {"Encryption", "salt=#{ub64(payload.salt)}"},
-      {"Crypto-Key", "dh=#{ub64(payload.server_public_key)}"},
-      {"Authorization", "key=#{auth_token}"}
+      {"Crypto-Key", "dh=#{ub64(payload.server_public_key)}"}
     ]
+
+    if isGcm do
+      endpoint = String.replace(endpoint, @gcm_url, @temp_gcm_url)
+      headers = headers ++ [{"Authorization", "key=#{auth_token}"}]
+    end
+
     HTTPoison.post(endpoint, payload.ciphertext, headers)
   end
   def send_web_push(_message, _subscription, _auth_token) do


### PR DESCRIPTION
- Adds a new call to send_web_push: auth_token is an optional parameter now so while we does not have optional parameters in defdelegate (waiting for 'Add defdelegate optional parameters. #4196' :-) ) we need a new head with only two parameters.
- Send "Authorization" header only for gcm endpoints.
- Use 'padding: false' option, mozilla returns subscription data without padding by default, with this option works in both cases with and without padding.
