### PR TITLE
Deprecated :crypto.rand_bytes in favor of strong_rand_bytes

### DIFF
--- a/lib/web_push_encryption/crypto.ex
+++ b/lib/web_push_encryption/crypto.ex
@@ -9,7 +9,7 @@ defmodule WebPushEncryption.Crypto do
   end
 
   def rand_bytes(bytes_num) do
-    impl.rand_bytes(bytes_num)
+    impl.strong_rand_bytes(bytes_num)
   end
 
   defp impl do

--- a/test/web_push_encryption/encrypt_test.exs
+++ b/test/web_push_encryption/encrypt_test.exs
@@ -29,7 +29,7 @@ defmodule WebPushEncryption.EncryptTest do
 
     @example_server_keys Module.get_attribute(WebPushEncryption.EncryptTest, :example_server_keys)
 
-    def rand_bytes(n) do
+    def strong_rand_bytes(n) do
       :binary.copy(<<0>>, n)
     end
 


### PR DESCRIPTION
Erlang's crypto has deprecated `rand_bytes` in favor of `strong_rand_bytes` [(reference)](http://erlang.org/doc/apps/crypto/notes.html#id69432), so this replaces the implementation defined in webpush's crypto module.