### PR TITLE
Clean up console warnings

### DIFF
--- a/lib/web_push_encryption/crypto.ex
+++ b/lib/web_push_encryption/crypto.ex
@@ -2,13 +2,13 @@ defmodule WebPushEncryption.Crypto do
   @moduledoc false
 
   @callback generate_key(atom, atom) :: {binary, binary}
-  @callback rand_bytes(non_neg_integer) :: binary
+  @callback strong_rand_bytes(non_neg_integer) :: binary
 
   def generate_key(type, params) do
     impl().generate_key(type, params)
   end
 
-  def rand_bytes(bytes_num) do
+  def strong_rand_bytes(bytes_num) do
     impl().strong_rand_bytes(bytes_num)
   end
 

--- a/lib/web_push_encryption/crypto.ex
+++ b/lib/web_push_encryption/crypto.ex
@@ -5,11 +5,11 @@ defmodule WebPushEncryption.Crypto do
   @callback rand_bytes(non_neg_integer) :: binary
 
   def generate_key(type, params) do
-    impl.generate_key(type, params)
+    impl().generate_key(type, params)
   end
 
   def rand_bytes(bytes_num) do
-    impl.strong_rand_bytes(bytes_num)
+    impl().strong_rand_bytes(bytes_num)
   end
 
   defp impl do

--- a/lib/web_push_encryption/encrypt.ex
+++ b/lib/web_push_encryption/encrypt.ex
@@ -55,7 +55,7 @@ defmodule WebPushEncryption.Encrypt do
     :ok = validate_length(client_auth_token, 16, "Subscription's Auth token is not 16 bytes.")
     :ok = validate_length(client_public_key, 65, "Subscription's client key (p256dh) is invalid.")
 
-    salt = Crypto.rand_bytes(16)
+    salt = Crypto.strong_rand_bytes(16)
 
     {server_public_key, server_private_key} = Crypto.generate_key(:ecdh, :prime256v1)
 

--- a/mix.exs
+++ b/mix.exs
@@ -11,8 +11,8 @@ defmodule WebPushEncryption.Mixfile do
      source_url: "https://github.com/tuvistavie/elixir-web-push-encryption",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     package: package,
-     deps: deps,
+     package: package(),
+     deps: deps(),
      docs: [source_ref: "#{@version}", extras: ["README.md"], main: "readme"]]
   end
 

--- a/test/web_push_encryption/encrypt_test.exs
+++ b/test/web_push_encryption/encrypt_test.exs
@@ -11,8 +11,6 @@ defmodule WebPushEncryption.EncryptTest do
     private: "uDNsfsz91y2ywQeOHljVoiUg3j5RGrDVAswRqjP3v90="
   }
 
-  @example_salt "AAAAAAAAAAAAAAAAAAAAAA"
-
   @valid_subscription %{
     endpoint: "https://example-endpoint.com/example/1234",
     keys: %{


### PR DESCRIPTION
Nothing major here but we like to keep our console output clean when possible. 

- Added a few missing parens.
- Removed unused `example_salt` attribute.
- Renamed `rand_bytes` to `strong_rand_bytes` to match the interface of `:crypto`.