### PR TITLE
Change mix.exs to specify extra_applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,7 @@ Elixir implementation of [Web Push Payload encryption](https://developers.google
   end
   ```
 
-2. Ensure `web_push_encryption` is started before your application:
-
-  ```elixir
-  def application do
-    [applications: [:web_push_encryption]]
-  end
-  ```
-
-3. Generate a web push Vapid keypair on the CLI and put it in your `config.exs` file:
+2. Generate a web push Vapid keypair on the CLI and put it in your `config.exs` file:
 
 ```
  $ mix do deps.get, compile

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule WebPushEncryption.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :httpoison]]
+    [extra_applications: [:logger]]
   end
 
   defp deps do


### PR DESCRIPTION
It would specify `applications:`, which is pre-1.4 syntax, and caused
the application's dependencies (JOSE, poison, etc) to be skipped when
building a release.

Also updated the README, it is no longer required to list
`:web_push_encryption` in your dependent applications explicitly.