### PR TITLE
Update mix version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Elixir implementation of [Web Push Payload encryption](https://developers.google
 
   ```elixir
   def deps do
-    [{:web_push_encryption, "~> 0.1.1"}]
+    [{:web_push_encryption, "~> 0.2.1"}]
   end
   ```
 


### PR DESCRIPTION
The mix version is out of date, which initially confused me on installation, because the old version depends on an outdated version of `httpoison` which caused a conflict.