### PR TITLE
Handle fcm endpoints

### DIFF
--- a/lib/web_push_encryption/push.ex
+++ b/lib/web_push_encryption/push.ex
@@ -5,8 +5,8 @@ defmodule WebPushEncryption.Push do
 
   alias WebPushEncryption.Vapid
 
-  @gcm_url "https://android.googleapis.com/gcm/send"
-  @temp_gcm_url "https://gcm-http.googleapis.com/gcm"
+  @fcm_url "https://fcm.googleapis.com/fcm/send"
+  @temp_fcm_url "https://fcm.googleapis.com/fcm"
 
   @doc """
   Sends a web push notification with a payload through GCM.
@@ -27,7 +27,7 @@ defmodule WebPushEncryption.Push do
           {:ok, any} | {:error, atom}
   def send_web_push(message, subscription, auth_token \\ nil)
 
-  def send_web_push(_message, %{endpoint: @gcm_url <> _registration_id}, nil) do
+  def send_web_push(_message, %{endpoint: @fcm_url <> _registration_id}, nil) do
     raise ArgumentError, "send_web_push requires an auth_token for gcm endpoints"
   end
 
@@ -56,7 +56,7 @@ defmodule WebPushEncryption.Push do
   end
 
   defp make_request_params(endpoint, headers, auth_token) do
-    if gcm_url?(endpoint) do
+    if fcm_url?(endpoint) do
       {make_gcm_endpoint(endpoint), headers |> Map.merge(gcm_authorization(auth_token))}
     else
       {endpoint, headers}
@@ -68,8 +68,8 @@ defmodule WebPushEncryption.Push do
     parsed.scheme <> "://" <> parsed.host
   end
 
-  defp gcm_url?(url), do: String.contains?(url, @gcm_url)
-  defp make_gcm_endpoint(endpoint), do: String.replace(endpoint, @gcm_url, @temp_gcm_url)
+  defp fcm_url?(url), do: String.contains?(url, @fcm_url)
+  defp make_gcm_endpoint(endpoint), do: String.replace(endpoint, @fcm_url, @temp_fcm_url)
   defp gcm_authorization(auth_token), do: %{"Authorization" => "key=#{auth_token}"}
 
   defp ub64(value) do

--- a/lib/web_push_encryption/push.ex
+++ b/lib/web_push_encryption/push.ex
@@ -6,7 +6,7 @@ defmodule WebPushEncryption.Push do
   alias WebPushEncryption.Vapid
 
   @fcm_url "https://fcm.googleapis.com/fcm/send"
-  @temp_fcm_url "https://fcm.googleapis.com/fcm"
+  @temp_fcm_url "https://fcm.googleapis.com/fcm/send"
 
   @doc """
   Sends a web push notification with a payload through GCM.

--- a/lib/web_push_encryption/push.ex
+++ b/lib/web_push_encryption/push.ex
@@ -30,6 +30,10 @@ defmodule WebPushEncryption.Push do
   def send_web_push(message, subscription, auth_token \\ nil)
 
   def send_web_push(_message, %{endpoint: @fcm_url <> _registration_id}, nil) do
+    raise ArgumentError, "send_web_push requires an auth_token for fcm endpoints"
+  end
+
+  def send_web_push(_message, %{endpoint: @gcm_url <> _registration_id}, nil) do
     raise ArgumentError, "send_web_push requires an auth_token for gcm endpoints"
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule WebPushEncryption.Mixfile do
   use Mix.Project
 
-  @version "0.2.1"
+  @version "0.2.2"
 
   def project do
     [

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,6 +2,7 @@ ExUnit.start()
 
 defmodule Fixtures do
   @gcm_url "https://android.googleapis.com/gcm/send"
+  @fcm_url "https://fcm.googleapis.com/fcm/send"
 
   def example_input(), do: "Hello, World."
   def example_output(), do: "CE2OS6BxfXsC2YbTdfkeWLlt4AKWbHZ3Fe53n5/4Yg=="
@@ -27,6 +28,10 @@ defmodule Fixtures do
 
   def valid_gcm_subscription() do
     Map.put(valid_subscription(), :endpoint, @gcm_url)
+  end
+
+  def valid_fcm_subscription() do
+    Map.put(valid_subscription(), :endpoint, @fcm_url)
   end
 end
 

--- a/test/web_push_encryption/push_test.exs
+++ b/test/web_push_encryption/push_test.exs
@@ -28,4 +28,15 @@ defmodule WebPushEncryption.PushTest do
     Push.send_web_push(Fixtures.example_input(), Fixtures.valid_gcm_subscription(), "auth_token")
     assert Enum.count(HTTPoisonSandbox.requests()) == 1
   end
+
+  test "fcm endpoint without auth_token" do
+    assert_raise ArgumentError, fn ->
+      Push.send_web_push(Fixtures.example_input(), Fixtures.valid_fcm_subscription())
+    end
+  end
+
+  test "fcm endpoint with auth_token" do
+    Push.send_web_push(Fixtures.example_input(), Fixtures.valid_fcm_subscription(), "auth_token")
+    assert Enum.count(HTTPoisonSandbox.requests()) == 1
+  end
 end


### PR DESCRIPTION
As gcm is being deprecated, Chrome 74+ is now using fcm endpoints when subscribing to notifications. fcm endpoints need the Authorization header as well, but do not need to change the url.