### PR TITLE
force poison v3 for test/dev only

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,14 @@ Elixir implementation of [Web Push Payload encryption](https://developers.google
 
 ## Installation
 
-1. Add `web_push_encryption` to your list of dependencies in `mix.exs`.
+1. Add `web_push_encryption` and a json library for jose to your list of dependencies in `mix.exs`.
 
   ```elixir
   def deps do
-    [{:web_push_encryption, "~> 0.2"}]
+    [
+      {:poison, "~> 0.4"}, # see jose docs for more options here
+      {:web_push_encryption, "~> 0.2"}
+    ]
   end
   ```
 

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule WebPushEncryption.Mixfile do
       app: :web_push_encryption,
       version: @version,
       elixir: "~> 1.4",
-      description: "Web push encryption lilbrary",
+      description: "Web push encryption library",
       source_url: "https://github.com/tuvistavie/elixir-web-push-encryption",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
@@ -26,7 +26,7 @@ defmodule WebPushEncryption.Mixfile do
     [
       {:httpoison, "~> 1.0"},
       {:jose, "~> 1.8"},
-      {:poison, "~> 3.0"},
+      {:poison, "~> 3.0", only: [:dev, :test]},
       {:earmark, "~> 1.0", only: :dev},
       {:ex_doc, "~> 0.11", only: :dev}
     ]


### PR DESCRIPTION
I think this is better, this should allow consumers of the library to choose the json library for jose that they want, right?