### PR TITLE
Fixed VAPID keygen task

### DIFF
--- a/lib/mix/tasks/web_push_gen_keypair.ex
+++ b/lib/mix/tasks/web_push_gen_keypair.ex
@@ -1,4 +1,18 @@
 defmodule Mix.Tasks.WebPush.Gen.Keypair do
+  @moduledoc """
+  Generate VAPID supplied config.
+
+  It will output something like this; 
+
+    config :web_push_encryption, :vapid_details,
+      subject: \"mailto:administrator@example.com\",
+      public_key: \"BPFoGQXYu4LgQvn_EXAMPLE_RgXSkYAEXkJO_SUP74cLsduMRd_zHd-CY7ACYQ\" ,
+      private_key: \"CJ4dlX4WIm_EXAMPLE_lZevqDPKwAyxs9k\"
+  """
+  @shortdoc "VAPID generator"
+
+  use Mix.Task
+
   def run(_) do
     {public, private} = :crypto.generate_key(:ecdh, :prime256v1)
 


### PR DESCRIPTION
In the readme.md in step 2 under the installation instruction. It mentions the following
```bash
 $ mix web_push.gen.keypair
 ```
 
 the `web_push.gen.keypair` option isnt available when running mix.
 Consulting the mix manual, it seems like you have to `use Mix.Task` to make it available as a task.
 
 This commit adds that and a short and long module doc.
 Perhaps not the best doc, but it is at least something :smile: 